### PR TITLE
Remove: Etiqueta de version en LogoBar

### DIFF
--- a/src/components/TopBar/LogoBar.jsx
+++ b/src/components/TopBar/LogoBar.jsx
@@ -45,12 +45,6 @@ const LogoBar = () => {
             alt="logo_MCI"
           />
         </div>
-
-        <div className="bg-blue-950 flex h-10">
-          <p className="text-white text-center text-sm font-bold mx-auto">
-            Versión {APP_VERSION}
-          </p>
-        </div>
       </div>
     </>
   );


### PR DESCRIPTION
Se removió la etiqueta de versión, ya se encuentra en producción, si hay cambios grandes en la página es conveniente modifcar la version desde el archivo json.